### PR TITLE
An additional config preload.exclude-files and repair travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: php
 php:
 - 7.2
 - 7.3
+- 7.4
 - nightly
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ php:
 - 7.2
 - 7.3
 - 7.4snapshot 
-- nightly
 
 env:
   matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: php
 php:
 - 7.2
 - 7.3
-- 7.4
+- 7.4snapshot 
 - nightly
 
 env:

--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ example:
             "no-status-check": false,
             "files": [
                 "somefile.php"
+            ],
+            "exclude-files": [
+                "web/some_file_in_paths_to_exclude.php"
             ]
         }
     }

--- a/README.md
+++ b/README.md
@@ -114,11 +114,17 @@ not enabled.
 An array of single files to be included. This setting is optional. The files must exist
  at the time `composer preload` command is run.
 
+- `extra.preload.exclude-files` : _Optional_
+
+An array of file with paths to exclude for. This option is suitable to blacklist a certain file that opcache will never 
+open but within the path and passes all regex tests. Example of files that may be exclude are phpinfo.php, a test
+file, shell scripts.
+
 # Preloading
 
 To do the actual preloading, execute `vendor/preload.php`. 
 
-If you have enabled opcache for CLI applications, you can directly call `php vendor/preload.php` to execute the 
+If you have enabled opcache for CLI ( _to enable opcache via CLI `opcache.enable_cli` at php.ini_ ) applications, you can directly call `php vendor/preload.php` to execute the 
 generated PHP file and warm up the cache right away. 
 
 Future versions of this plugin will have a feature to generate the file _and_ immediately run it.

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.2 | ^8.0",
         "composer-plugin-api": "^1.0",
         "ayesh/php-timer": "^2.0.1",
         "symfony/finder": "^3.4.18 | ^4.0.14 | ^4.1.7 | ^4.2.0"

--- a/src/Composer/Command/PreloadCommand.php
+++ b/src/Composer/Command/PreloadCommand.php
@@ -58,10 +58,6 @@ HELP
       $writer->setStatusCheck(false);
     }
 
-    if(\isset($this->config['exclude-files'])) {
-      $writer->setExcludeFiles($this->config['exclude-files']))
-    }
-    
     $writer->write();
 
     $io = $this->getIO();
@@ -101,7 +97,9 @@ HELP
       $generator->addIncludeExtension($extension);
     }
 
-    $generator->setExcludeFiles($this->config['exclude-files']);
+    if(isset($this->config['exclude-files'])) {
+      $generator->addExcludeFiles($this->config['exclude-files']);
+    }
 
     return $generator->getList();
   }

--- a/src/Composer/Command/PreloadCommand.php
+++ b/src/Composer/Command/PreloadCommand.php
@@ -58,6 +58,10 @@ HELP
       $writer->setStatusCheck(false);
     }
 
+    if(\isset($this->config['exclude-files'])) {
+      $writer->setExcludeFiles($this->config['exclude-files']))
+    }
+    
     $writer->write();
 
     $io = $this->getIO();
@@ -86,7 +90,7 @@ HELP
     foreach ($this->config['paths'] as $path) {
       $generator->addPath($path);
     }
-
+    
     foreach ($this->config['exclude'] as $path) {
       $generator->addExcludePath($path);
     }
@@ -96,6 +100,8 @@ HELP
     foreach ($this->config['extensions'] as $extension) {
       $generator->addIncludeExtension($extension);
     }
+
+    $generator->setExcludeFiles($this->config['exclude-files']);
 
     return $generator->getList();
   }

--- a/src/PreloadFinder.php
+++ b/src/PreloadFinder.php
@@ -34,8 +34,8 @@ class PreloadFinder {
     $this->include_files[] =  new \SplFileInfo($file_name);
   }
 
-  public function addExcludedFiles(array $files): void {
-    $this->excluded_files = $files;
+  public function addExcludeFiles(array $files): void {
+    $this->exclude_files = $files;
   }
   
   public function addIncludePath(string $dir_name): void {
@@ -81,13 +81,13 @@ class PreloadFinder {
   private function getExcludeCallable(): ?callable {
     $regex_dir = $this->getDirectoryExclusionRegex();
     $regex_static = $this->exclude_regex_static;
-    $excludedFiles = $this->excluded_files;
+    $excludeFiles = $this->exclude_files;
 
     if (!$regex_dir && $this->exclude_regex_static === null) {
       return null;
     }
 
-    return function (\SplFileInfo $file) use ($regex_dir, $regex_static, $excludedFiles): bool {
+    return function (\SplFileInfo $file) use ($regex_dir, $regex_static, $excludeFiles): bool {
       $path = str_replace('\\', '/', $file->getPathname());
       $exclude_match = false;
       if ($regex_dir) {
@@ -100,7 +100,7 @@ class PreloadFinder {
       }
 
       // If excluded due to regex matching above, don't run singular file regex.
-      if(!$exclude_match && in_array($path, $excludedFiles)) {
+      if(!$exclude_match && in_array($path, $excludeFiles)) {
         $exclude_match = true;
       }
 

--- a/src/PreloadGenerator.php
+++ b/src/PreloadGenerator.php
@@ -38,4 +38,8 @@ class PreloadGenerator {
   public function addIncludeExtension(string $extension): void {
     $this->finder->addIncludeExtension($extension);
   }
+
+  public function addExcludeFiles(array $files): void {
+    $this->finder->addExcludeFiles($files);
+  }
 }


### PR DESCRIPTION
**Additional Config ```preload.exclude-files```**
Sometimes you will face an issue  that packages included within path (example vendor) has a default file. Executing ```vendor/preload.php``` can throw error as conflict of class name or function. So came out with a config to exclude this one file only.


**Repair Travis**
 PHP Compatibility at composer.json was set to ^7.2 where else travis.yml was set nightly. Current nightly is 8.0.0-dev
