### PR TITLE
Fix getIterator must be compatible with interface

### DIFF
--- a/src/PreloadList.php
+++ b/src/PreloadList.php
@@ -4,6 +4,7 @@ namespace Ayesh\ComposerPreload;
 
 use BadMethodCallException;
 use IteratorAggregate;
+use Traversable;
 
 final class PreloadList implements IteratorAggregate {
 
@@ -16,7 +17,7 @@ final class PreloadList implements IteratorAggregate {
         $this->list = $list;
     }
 
-    public function getIterator(): iterable {
+    public function getIterator(): Traversable {
         if (!$this->list) {
             throw new BadMethodCallException('Attempting to fetch the iterator without setting one first.');
         }


### PR DESCRIPTION
Deprecation notice in php 8.1:
```
Deprecation Notice: Return type of Ayesh\ComposerPreload\PreloadList::getIterator(): iterable should either be compatible with IteratorAggregate::getIterator(): Traversable, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /tmp/php/build/hbw/vendor/ayesh/composer-preload/src/PreloadList.php:19
```

I saw no reason to use the attribute to suppress the notice than to fix it since this class is final.